### PR TITLE
Remove asn configuration option

### DIFF
--- a/src/config.yaml
+++ b/src/config.yaml
@@ -1,9 +1,1 @@
 options:
-  asn:
-    default:
-    type: int
-    description: |
-      BGP Autonomous System Number for the OpenStack networks being advertised.
-      This setting is primarily used for testing. In production use ASNs are
-      configured post-deployment via the OpenStack client when creating bgp
-      speakers.

--- a/src/reactive/dragent_handlers.py
+++ b/src/reactive/dragent_handlers.py
@@ -38,8 +38,7 @@ charm.use_defaults(
 def publish_bgp_info(endpoint):
     """Publish BGP information about this unit to interface-bgp peers
     """
-    endpoint.publish_info(asn=hookenv.config('asn'),
-                          passive=True,
+    endpoint.publish_info(passive=True,
                           bindings=dragent.bgp_speaker_bindings())
     dragent.assess_status()
 

--- a/src/tests/bundles/bionic-queens-functional.yaml
+++ b/src/tests/bundles/bionic-queens-functional.yaml
@@ -28,7 +28,6 @@ applications:
   neutron-dynamic-routing:
     charm: ../../../neutron-dynamic-routing
     num_units: 1
-    options: {asn: 12345}
     series: bionic
   rabbitmq-server:
     charm: cs:~openstack-charmers-next/bionic/rabbitmq-server
@@ -38,6 +37,5 @@ applications:
   quagga:
     charm: cs:~openstack-charmers-next/bionic/quagga
     num_units: 1
-    options: {asn: 10000}
     series: bionic
 

--- a/src/tests/bundles/xenial-pike-functional.yaml
+++ b/src/tests/bundles/xenial-pike-functional.yaml
@@ -30,7 +30,7 @@ applications:
   neutron-dynamic-routing:
     charm: ../../../neutron-dynamic-routing
     num_units: 1
-    options: {asn: 12345, openstack-origin: 'cloud:xenial-pike/proposed'}
+    options: {openstack-origin: 'cloud:xenial-pike/proposed'}
     series: xenial
   rabbitmq-server:
     charm: cs:~openstack-charmers-next/xenial/rabbitmq-server
@@ -41,6 +41,5 @@ applications:
   quagga:
     charm: cs:~openstack-charmers-next/xenial/quagga
     num_units: 1
-    options: {asn: 10000}
     series: xenial
 

--- a/src/tests/bundles/xenial-queens-functional.yaml
+++ b/src/tests/bundles/xenial-queens-functional.yaml
@@ -29,7 +29,7 @@ applications:
   neutron-dynamic-routing:
     charm: ../../../neutron-dynamic-routing
     num_units: 1
-    options: {asn: 12345, openstack-origin: 'cloud:xenial-queens/proposed'}
+    options: {openstack-origin: 'cloud:xenial-queens/proposed'}
     series: xenial
   rabbitmq-server:
     charm: cs:~openstack-charmers-next/xenial/rabbitmq-server
@@ -40,6 +40,5 @@ applications:
   quagga:
     charm: cs:~openstack-charmers-next/xenial/quagga
     num_units: 1
-    options: {asn: 10000}
     series: xenial
 

--- a/unit_tests/test_dragent_handlers.py
+++ b/unit_tests/test_dragent_handlers.py
@@ -122,15 +122,11 @@ class TestDRAgentHandlers(unittest.TestCase):
                                  "{}: incorrect state registration".format(f))
 
     def test_publish_bgp_info(self):
-        _asn = 12345
         _bindings = ['bgp-speaker']
         self.patch(handlers.dragent, 'assess_status')
-        self.patch(handlers.hookenv, 'config')
-        self.config.return_value = _asn
         bgp = mock.MagicMock()
         handlers.publish_bgp_info(bgp)
-        bgp.publish_info.assert_called_once_with(asn=_asn,
-                                                 passive=True,
+        bgp.publish_info.assert_called_once_with(passive=True,
                                                  bindings=_bindings)
 
     def test_setup_amqp_req(self):


### PR DESCRIPTION
This configuration option is only used for CI testing and
may be confusing for a unsuspecting end user.

Change is coupled with openstack-charmers/zaza#48 that updates the dragent
test to get information about configured asns by inspecting
relation data on `neutron-dynamic-routing` and `quagga`
units.